### PR TITLE
Changed local install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,24 +135,14 @@
 
 ## <a name="local"></a>:desktop_computer: Running Rita Locally
 
-*The bot can also be run locally on a device. The local setup requires more steps since the database needs to be setup and the development tools need be installed. Please note that for the bot to continue running 24/7, the process of `node src/bot.js` should always remain online and thus your PC/hosting device must remain online too*
+*The bot can also be run locally on a device. Please note that for the bot to continue running 24/7, the process of `node src/bot.js` should always remain online and thus your PC/hosting device must remain online too*
 
-#### 1. Create a local database
-Any Database that runs with [SQL Sequelize](https://sequelize.org/master/) can be used. My recommendation is to use the [SQL Lite](https://www.sqlite.org/index.html) database since the setup is fast and access is easy. Copy the connection details to the database for the next step. Example: The connection to a sqlite database with the name *`database.db`* stored at the same level of this README file would be *`./database.db`*.
-
-#### 2. Install necessary software
-Install [node.js](https://nodejs.org/en/) and make sure you have [Git](https://git-scm.com/downloads) and [npm](https://www.npmjs.com/get-npm) installed
-
-#### 4. Install the bot
-* Run **```git clone https://github.com/RitaBot-Project/RitaBot```**
-* Download dependencies using **`npm install`**
-
-#### 5. Create a new .env File
-Rename the existing **.env.example** file and name it **.env**. Edit the Values of **DISCORD_TOKEN**, and the **DATABASE_URL** according to the values that you in [Step 2 of "Setting Up a New Bot"](#new-bot) .
-  * DATABASE_URL needs to be the path to the database file (if you set **`DATABASE_URL`** to any of these values: `./database.db`, `C:/FOLDER/ok.db`, `../random.db` they will all work because they lead to a directory in which SQLite then creates the `.db` file )
-    * Example -  `DATABASE_URL` = `C:\Admin\Rita_Development\test.db`
-
-#### 5. Invite your bot to your server and configure it!
+1. Install [node.js](https://nodejs.org/en/). It comes with [npm](https://www.npmjs.com/get-npm) which you will need.
+2. Simply download this repository as a .zip, or clone it if you have git: **```git clone https://github.com/RitaBot-Project/RitaBot```**
+3. In the RitaBot folder, rename the existing **.env.example** file and name it **.env**. Edit the Value of **DISCORD_TOKEN**. (If you don't have a bot account, see [Step 2 of "Setting Up a New Bot"](#new-bot))
+4. Open a terminal/console in the RitaBot folder and download dependencies using **`npm install`**
+5. Start the bot with **`npm start`**
+6. Invite your bot to your server and configure it!
 * Replace the **CLIENTID** string in the following URL with your own apps client id: https://discordapp.com/oauth2/authorize?&client_id=**CLIENTID**&scope=bot&permissions=8
   * Visit the resulting URL and add your bot to any server where you have admin privileges.
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@
 
 * Your bot is now setup and ready for any translation you have for it to do. Use the commands `!tr help` and `!tr help modules` to learn more about the commands Rita has!
 
+#### Alternative Database Settings
+Any Database that runs with [SQL Sequelize](https://sequelize.org/master/) can be used. If you want to use an alternative DB Location other than in the default directory then you can manually set this. Example: The connection to a sqlite database with the name *`database.db`* stored at the same level of this README file would be *`./database.db`*.
+
+Within the **.env** file from the above step, set the **DATABASE_URL** to be the path to the database file, if there is no DB file in the selected path then RITA will create the DB file upon startup.
+* Example -  `DATABASE_URL` = `C:\Admin\Rita_Development\test.db`
+
 ## <a name="database"></a>Heroku Database Support
 Sometimes you need to edit the Database manually, This is not something you should be playing around with unless you really know what you are doing.
 

--- a/README.md
+++ b/README.md
@@ -143,11 +143,10 @@
 4. Open a terminal/console in the RitaBot folder and download dependencies using **`npm install`**
 5. Start the bot with **`npm start`**
 6. Invite your bot to your server and configure it!
-* Replace the **CLIENTID** string in the following URL with your own apps client id: https://discordapp.com/oauth2/authorize?&client_id=**CLIENTID**&scope=bot&permissions=8
-  * Visit the resulting URL and add your bot to any server where you have admin privileges.
 
-* Once added, your bot should show up as online. 
-  * Your bot is now setup and ready for any translation you have for it to do. Use the commands `!tr help` and `!tr help modules` to learn more about the commands Rita has!
+* If you don't already have a invite for your bot, you can replace the **CLIENTID** string in the following URL with your own apps client id: https://discordapp.com/oauth2/authorize?&client_id=**CLIENTID**&scope=bot&permissions=8 . Visit the resulting URL and add your bot to any server where you have admin privileges. Once added, your bot should show up as online.
+
+* Your bot is now setup and ready for any translation you have for it to do. Use the commands `!tr help` and `!tr help modules` to learn more about the commands Rita has!
 
 ## <a name="database"></a>Heroku Database Support
 Sometimes you need to edit the Database manually, This is not something you should be playing around with unless you really know what you are doing.


### PR DESCRIPTION
I removed steps that you don't have to do, and streamlined the process.
The old ones were a bit confusing for me - Because there's actually no need to set up or configure the database. The default settings work just fine, Sqlite3 is is installed when you do npm install. There's little reason to change the directory of the database.

I think this makes it much easier to install, and to install what you actually need to do to install it.
PS. Great bot, I love it